### PR TITLE
Replace xtend with Object.assign

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 
 var through2 = require('through2');
 var get = require('lodash.get');
-var xtend = require('xtend');
 
 var ZERO_BYTE_STRING = '';
 
@@ -12,7 +11,7 @@ function ctor(options, propPath, defaultValue) {
     propPath = options;
     options = {};
   }
-  options = xtend({objectMode: true, highWaterMark: 16, excludeZBS: true}, options)
+  options = Object.assign({objectMode: true, highWaterMark: 16, excludeZBS: true}, options)
 
   var Get = through2.ctor(options, function (chunk, encoding, cb) {
     var out = get(chunk, propPath, defaultValue);

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
   "homepage": "https://github.com/jamesramsay/through2-get",
   "dependencies": {
     "lodash.get": "^4.0.0",
-    "through2": "^2.0.0",
-    "xtend": "4.0.1"
+    "through2": "^2.0.0"
   },
   "devDependencies": {
     "ava": "^0.19.0",


### PR DESCRIPTION
Object.assign is available on all supported node versions.