### PR TITLE
Require Node.js 6.9 and upgrade through2 to version 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var through2 = require('through2');
-var get = require('lodash.get');
+var get = require('lodash/get');
 
 var ZERO_BYTE_STRING = '';
 

--- a/package.json
+++ b/package.json
@@ -50,10 +50,10 @@
     "codecov.io": "^0.1.6",
     "eslint": "^4.15.0",
     "eslint-config-airbnb-base": "^12.1.0",
-    "eslint-plugin-ava": "^4.3.0",
+    "eslint-plugin-ava": "^4.5.1",
     "eslint-plugin-import": "^2.8.0",
     "istanbul": "^0.4.1",
-    "nyc": "^11.3.0"
+    "nyc": "^14.1.1"
   },
   "publishConfig": {
     "tag": "latest"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "homepage": "https://github.com/jamesramsay/through2-get",
   "dependencies": {
     "lodash.get": "^4.0.0",
-    "through2": "^2.0.0"
+    "through2": "^4.0.2"
   },
   "devDependencies": {
     "ava": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "check-node-version": "^3.0.0",
     "codecov.io": "^0.1.6",
     "eslint": "^4.15.0",
-    "eslint-config-airbnb-base": "^12.1.0",
+    "eslint-config-airbnb-base": "^13.2.0",
     "eslint-plugin-ava": "^4.5.1",
     "eslint-plugin-import": "^2.8.0",
     "istanbul": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://github.com/jamesramsay/through2-get",
   "dependencies": {
-    "lodash.get": "^4.0.0",
+    "lodash": "^4.17.20",
     "through2": "^4.0.2"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import get from '../';
+import get from '..';
 
 test.cb('should not return content when no input provided', (t) => {
   const getContent = get('content');


### PR DESCRIPTION
@realityking https://github.com/jamesramsay/through2-get/pull/116#issue-536871780:

> This is a very conservative approach, bumping the Node requirement only as much as necessary to be able to use thorugh2 v4.
> 
> This will help hercule with deduplication as it already depends on through2 v3. I'll push a PR there that pulls it up to v4 when there's a new release of through2.
> 
> The last commit in the PR changes the way lodash is required. It's not strictly necessary but it helps deduplication in hercule (and in general) as it and other many packages depend on the full lodash and it's thus likely already in the dependency tree.
