### PR TITLE
Don't ship files only needed in development

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,3 @@
 test
+.github
+.eslintrc.json


### PR DESCRIPTION
It's not making a big difference size wise (<10 kB on disk) but it's nice to clean this up.